### PR TITLE
Fix scoring element cast

### DIFF
--- a/SliceDetails/SliceRecorder.cs
+++ b/SliceDetails/SliceRecorder.cs
@@ -81,11 +81,8 @@ namespace SliceDetails
 		}
 
 		public void ScoringForNoteFinishedHandler(ScoringElement scoringElement) {
-			NoteInfo noteSwingInfo;
-			if (_noteSwingInfos.TryGetValue(scoringElement.noteData, out noteSwingInfo))
+			if (_noteSwingInfos.TryGetValue(scoringElement.noteData, out NoteInfo noteSwingInfo) && scoringElement is GoodCutScoringElement goodScoringElement)
 			{
-				GoodCutScoringElement goodScoringElement = (GoodCutScoringElement)scoringElement;
-
 				IReadonlyCutScoreBuffer cutScoreBuffer = goodScoringElement.cutScoreBuffer;
 
 				int preSwing = cutScoreBuffer.beforeCutScore;

--- a/SliceDetails/manifest.json
+++ b/SliceDetails/manifest.json
@@ -3,9 +3,9 @@
   "id": "SliceDetails",
   "name": "SliceDetails",
   "author": "ckosmic",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "View your average cuts per-angle per-grid position in the pause menu and completion screen.",
-  "gameVersion": "1.20.0",
+  "gameVersion": "1.29.1",
   "dependsOn": {
     "BSIPA": "^4.2.1",
     "BeatSaberMarkupLanguage": "^1.6.0",


### PR DESCRIPTION
The game has different subtypes of scoring elements. Blindly casting it to `GoodCutScoringElement` will cause exceptions for non-good cuts.
This is breaking the BeatLeader replay viewer. I haven't noticed it breaking normal plays though.

![image](https://github.com/ckosmic/SliceDetails/assets/31044781/b5b05c4e-a52f-497b-82b4-d3dec3935b4a)
